### PR TITLE
docs: add Lightcone to Plugins and Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ OpenClaw is an open-source, self-hosted AI agent framework that connects LLMs to
 - [rickybloomfield/OuraClaw](https://github.com/rickybloomfield/OuraClaw) - Oura integration plugin for readiness, sleep, and activity summaries. ![GitHub stars](https://img.shields.io/github/stars/rickybloomfield/OuraClaw?style=social)
 - [soimy/openclaw-channel-dingtalk](https://github.com/soimy/openclaw-channel-dingtalk) - DingTalk enterprise channel plugin with stream support. ![GitHub stars](https://img.shields.io/github/stars/soimy/openclaw-channel-dingtalk?style=social)
 - [techartdev/OpenClawHomeAssistant](https://github.com/techartdev/OpenClawHomeAssistant) - Home Assistant add-on with entity-level integration. ![GitHub stars](https://img.shields.io/github/stars/techartdev/OpenClawHomeAssistant?style=social)
+- [tzafon/openclaw-lightcone](https://github.com/tzafon/openclaw-lightcone) - OpenClaw cloud browser automation plugin via Lightcone (Tzafon). ![GitHub stars](https://img.shields.io/github/stars/tzafon/openclaw-lightcone?style=social)
 
 ## MCP and Tool Servers
 


### PR DESCRIPTION
Closes #17

Adds the `tzafon/openclaw-lightcone` plugin to the **Plugins and Integrations** section. This is a cloud browser automation plugin for OpenClaw using the Lightcone API.