### PR TITLE
feat(readme): add OpenClaw-MemCraft plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ OpenClaw is an open-source, self-hosted AI agent framework that connects LLMs to
 
 - [11haonb/wecom-openclaw-plugin](https://github.com/11haonb/wecom-openclaw-plugin) - WeCom (WeChat Work) enterprise messaging plugin. ![GitHub stars](https://img.shields.io/github/stars/11haonb/wecom-openclaw-plugin?style=social)
 - [AlexAnys/feishu-openclaw](https://github.com/AlexAnys/feishu-openclaw) - Feishu/Lark integration plugin with streamlined self-hosted setup. ![GitHub stars](https://img.shields.io/github/stars/AlexAnys/feishu-openclaw?style=social)
+- [bebr2/OpenClaw-MemCraft](https://github.com/bebr2/OpenClaw-MemCraft) -  A customizable and extensible memory plugin for OpenClaw. ![GitHub stars](https://img.shields.io/github/stars/bebr2/OpenClaw-MemCraft?style=social)
 - [ClariSortAi/openclaw-manager-plugin](https://github.com/ClariSortAi/openclaw-manager-plugin) - Lifecycle manager for install and configuration workflows. ![GitHub stars](https://img.shields.io/github/stars/ClariSortAi/openclaw-manager-plugin?style=social)
 - [Crossmint/openclaw-crossmint-plugin](https://github.com/Crossmint/openclaw-crossmint-plugin) - On-chain wallet and payments for agents. ![GitHub stars](https://img.shields.io/github/stars/Crossmint/openclaw-crossmint-plugin?style=social)
 - [DNYoussef/guardspine-openclaw](https://github.com/DNYoussef/guardspine-openclaw) - Governance plugin with deny-by-default gating and risk tiers. ![GitHub stars](https://img.shields.io/github/stars/DNYoussef/guardspine-openclaw?style=social)


### PR DESCRIPTION
[bebr2/OpenClaw-MemCraft](https://github.com/bebr2/OpenClaw-MemCraft)

**Short description:** A meory system integration plugin that brings local, extensible LLM memory baselines to OpenClaw.  Users can diy their own memory system easily.

**Which section it belongs in:** Plugins and Integrations 

**Evidence of relevance to OpenClaw**: It is an OpenClaw lifecycle plugin that hooks into `before_prompt_build` and `session/agent endings` to inject and store memory. Can use `openclaw plugins install memcraft-openclaw-plugin@latest` to install.

Closes #22 
