### PR TITLE
Add tubeify + lobsterdomains to Skills and Skill Indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,12 +82,14 @@ OpenClaw is an open-source, self-hosted AI agent framework that connects LLMs to
 - [BankrBot/openclaw-skills](https://github.com/BankrBot/openclaw-skills) - Community skill library focused on automation and finance. ![GitHub stars](https://img.shields.io/github/stars/BankrBot/openclaw-skills?style=social)
 - [clawdbot/skills](https://github.com/openclaw/skills) - Legacy alias path to historical skill archive content. ![GitHub stars](https://img.shields.io/github/stars/openclaw/skills?style=social)
 - [jdrhyne/agent-skills](https://github.com/jdrhyne/agent-skills) - Agent skill packs and reusable workflow extensions. ![GitHub stars](https://img.shields.io/github/stars/jdrhyne/agent-skills?style=social)
+- [lobsterdomains](https://clawhub.ai/esokullu/lobsterdomains) - Register ICANN domains with crypto (USDC/ETH/BTC) via API, built for AI agents.
 - [lekt9/unbrowse-openclaw](https://github.com/lekt9/unbrowse-openclaw) - API-skill generation workflow from captured web/API traffic. ![GitHub stars](https://img.shields.io/github/stars/lekt9/unbrowse-openclaw?style=social)
 - [openclaw/clawhub](https://github.com/openclaw/clawhub) - Official skill directory and discovery surface. 🎖️ ![GitHub stars](https://img.shields.io/github/stars/openclaw/clawhub?style=social)
 - [openclaw/skills](https://github.com/openclaw/skills) - Archived versions of skills published on ClawHub. 🎖️ ![GitHub stars](https://img.shields.io/github/stars/openclaw/skills?style=social)
 - [pors/skill-audit](https://github.com/pors/skill-audit) - Skill auditing toolkit for validating and hardening skill quality. ![GitHub stars](https://img.shields.io/github/stars/pors/skill-audit?style=social)
 - [runkids/skillshare](https://github.com/runkids/skillshare) - Share and synchronize skill packs across AI coding tools. ![GitHub stars](https://img.shields.io/github/stars/runkids/skillshare?style=social)
 - [Skills.sh OpenClaw Directory](https://skills.sh/openclaw/openclaw) - Third-party OpenClaw skill discovery directory.
+- [tubeify](https://clawhub.ai/esokullu/tubeify) - AI video editor for YouTube — removes pauses and filler words from raw recordings via API.
 - [Virtual-Protocol/openclaw-acp](https://github.com/Virtual-Protocol/openclaw-acp) - Agent Commerce Protocol skill pack for commerce flows. ![GitHub stars](https://img.shields.io/github/stars/Virtual-Protocol/openclaw-acp?style=social)
 
 ## Plugins and Integrations


### PR DESCRIPTION
## Two new skills

Both are published on ClawHub and built specifically for AI agent workflows.

**[tubeify](https://clawhub.ai/esokullu/tubeify)** — AI video editor for YouTube creators. Removes pauses, filler words, and dead air from raw recordings via REST API. Pay-per-video ($2 USDC), no subscription. `clawhub install tubeify`

**[lobsterdomains](https://clawhub.ai/esokullu/lobsterdomains)** — Register ICANN domains (.com/.xyz/.org/1000+ TLDs) with on-chain crypto payments (USDC/USDT/ETH/BTC). REST API built for AI agents to acquire domains fully autonomously. `clawhub install lobsterdomains`
