### PR TITLE
Add ClawBob provider to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ OpenClaw is an open-source, self-hosted AI agent framework that connects LLMs to
 These providers handle the setup for you: no Docker, no terminal, no DevOps required.
 
 - [Agent37](https://www.agent37.com/openclaw) - Managed OpenClaw instance with near-instant provisioning. 💵
+- [ClawBob](https://clawbob.com/en) - Hosted in the EU. Comes with dedicated email, kanban, and secure defaults built in. 💵
 - [ClawCloud](https://www.clawcloud.sh/) - Managed OpenClaw hosting with auto-updates and backups. 💵
 - [ClawSimple](https://clawsimple.com/en) - Managed OpenClaw hosting with simple plans and setup. 💵
 - [Contabo OpenClaw](https://contabo.com/en-us/openclaw-hosting/) - VPS-based OpenClaw hosting option with predictable pricing. 💵


### PR DESCRIPTION
Adds ClawBob to the managed hosting section.

ClawBob is a hosted OpenClaw option with EU hosting and built-in defaults (dedicated email, kanban, secure setup), aimed at users looking for a simpler setup path without handling infrastructure.