### PR TITLE
Add wechat-send: WeChat personal messaging via AppleScript on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ OpenClaw is an open-source, self-hosted AI agent framework that connects LLMs to
 - [rickybloomfield/OuraClaw](https://github.com/rickybloomfield/OuraClaw) - Oura integration plugin for readiness, sleep, and activity summaries. ![GitHub stars](https://img.shields.io/github/stars/rickybloomfield/OuraClaw?style=social)
 - [soimy/openclaw-channel-dingtalk](https://github.com/soimy/openclaw-channel-dingtalk) - DingTalk enterprise channel plugin with stream support. ![GitHub stars](https://img.shields.io/github/stars/soimy/openclaw-channel-dingtalk?style=social)
 - [techartdev/OpenClawHomeAssistant](https://github.com/techartdev/OpenClawHomeAssistant) - Home Assistant add-on with entity-level integration. ![GitHub stars](https://img.shields.io/github/stars/techartdev/OpenClawHomeAssistant?style=social)
+- [TonyLTalentexe/wechat-send](https://github.com/TonyLTalentexe/wechat-send) - WeChat personal messaging via AppleScript on macOS. Zero ban risk, keyboard-driven automation. ![GitHub stars](https://img.shields.io/github/stars/TonyLTalentexe/wechat-send?style=social)
 
 ## MCP and Tool Servers
 


### PR DESCRIPTION
## What

Adds [wechat-send](https://github.com/TonyLTalentexe/wechat-send) to the Plugins and Integrations section.

## About the tool

A shell script that automates WeChat Mac desktop client to send text messages using AppleScript + cliclick.

- **Approach**: Pure keyboard simulation + clipboard, no protocol hacking or DLL injection
- **Ban risk**: Zero — mimics human interaction, indistinguishable from real user
- **Use case**: AI agents (OpenClaw / Claude Code) sending WeChat messages programmatically
- **Platform**: macOS 12+ / WeChat Mac 4.1.x
- **License**: MIT

## Why it fits this list

Fills a gap in the messaging plugin ecosystem — WeChat personal accounts have no API, and existing automation tools (WeChatFerry, wxauto) only work on Windows. This is the first macOS-native solution for AI agents to send WeChat messages.

Complements existing messaging plugins: WeCom (enterprise), QQ, Feishu/Lark, DingTalk.