### PR TITLE
Add ToolRouter — one gateway to 150+ MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ OpenClaw is an open-source, self-hosted AI agent framework that connects LLMs to
 - [androidStern-personal/openclaw-mcp-adapter](https://github.com/androidStern-personal/openclaw-mcp-adapter) - adapter for native OpenClaw tool access. ![GitHub stars](https://img.shields.io/github/stars/androidStern-personal/openclaw-mcp-adapter?style=social)
 - [Enderfga/openclaw-claude-code-skill](https://github.com/Enderfga/openclaw-claude-code-skill) - Claude Code skill integration via MCP for OpenClaw. ![GitHub stars](https://img.shields.io/github/stars/Enderfga/openclaw-claude-code-skill?style=social)
 - [Helms-AI/openclaw-mcp-server](https://github.com/Helms-AI/openclaw-mcp-server) - MCP server exposing OpenClaw Gateway tools. ![GitHub stars](https://img.shields.io/github/stars/Helms-AI/openclaw-mcp-server?style=social)
+- [ToolRouter](https://toolrouter.com) - One gateway to 150+ tools for AI agents — SEO, screenshots, web search, image generation, video, security scanning, and more. One API key replaces managing dozens of provider accounts. Works with ChatGPT, Claude, Cursor, and any MCP client. Growing daily. `npx -y toolrouter-mcp` | Remote: `https://api.toolrouter.com/mcp` 💵
 
 ## Media and Papers
 


### PR DESCRIPTION
Adds ToolRouter — a unified MCP gateway that gives agents access to 150+ tools through one connection. One API key replaces managing dozens of separate provider accounts.

Works with ChatGPT, Claude, Cursor, Windsurf, and any MCP-compatible client. Growing daily.

- Website: https://toolrouter.com
- npm: https://www.npmjs.com/package/toolrouter-mcp
- Remote MCP: https://api.toolrouter.com/mcp