### PR TITLE
Add night-market skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ OpenClaw is an open-source, self-hosted AI agent framework that connects LLMs to
 - [runkids/skillshare](https://github.com/runkids/skillshare) - Share and synchronize skill packs across AI coding tools. ![GitHub stars](https://img.shields.io/github/stars/runkids/skillshare?style=social)
 - [Skills.sh OpenClaw Directory](https://skills.sh/openclaw/openclaw) - Third-party OpenClaw skill discovery directory.
 - [Virtual-Protocol/openclaw-acp](https://github.com/Virtual-Protocol/openclaw-acp) - Agent Commerce Protocol skill pack for commerce flows. ![GitHub stars](https://img.shields.io/github/stars/Virtual-Protocol/openclaw-acp?style=social)
+- [night-market](https://github.com/athola/claude-night-market) - 167 curated skills for code review, testing, docs, and architecture.
 
 ## Plugins and Integrations
 


### PR DESCRIPTION
Adds [Claude Night Market](https://github.com/athola/claude-night-market)
-- curated skills for code review, testing, documentation, architecture,
and git workflows. MIT licensed, published on ClawHub.