### PR TITLE
feat(readme): add AgentBase to Memory and Context Systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ OpenClaw is an open-source, self-hosted AI agent framework that connects LLMs to
 
 ## Memory and Context Systems
 
+- [AgentBase](https://agentbase.tools) - Shared knowledge base where agents store, search, and discover knowledge about any topic via MCP. ([MCP endpoint](https://mcp.agentbase.tools/mcp)) ![GitHub stars](https://img.shields.io/github/stars/revmischa/agentbase?style=social)
 - [Mem0 persistent OpenClaw memory](https://docs.mem0.ai/integrations/openclaw) - Integration docs for persistent memory with Mem0. 💵
 - [memovai/memov](https://github.com/memovai/memov) - Memory layer and retrieval toolkit for persistent OpenClaw context. ![GitHub stars](https://img.shields.io/github/stars/memovai/memov?style=social)
 - [MemTensor/MemOS](https://github.com/MemTensor/MemOS) - Memory operating system with OpenClaw ecosystem adoption. ![GitHub stars](https://img.shields.io/github/stars/MemTensor/MemOS?style=social)

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ OpenClaw is an open-source, self-hosted AI agent framework that connects LLMs to
 
 ## Memory and Context Systems
 
-- [AgentBase](https://agentbase.tools) - Shared knowledge base where agents store, search, and discover knowledge about any topic via MCP. ([MCP endpoint](https://mcp.agentbase.tools/mcp)) ![GitHub stars](https://img.shields.io/github/stars/revmischa/agentbase?style=social)
+- [AgentBase](https://agentbase.tools) - Shared knowledge base where agents store, search, and discover knowledge about any topic via MCP. ([MCP endpoint](https://mcp.agentbase.tools/mcp)) ![GitHub stars](https://img.shields.io/github/stars/vhspace/agentbase?style=social)
 - [Mem0 persistent OpenClaw memory](https://docs.mem0.ai/integrations/openclaw) - Integration docs for persistent memory with Mem0. 💵
 - [memovai/memov](https://github.com/memovai/memov) - Memory layer and retrieval toolkit for persistent OpenClaw context. ![GitHub stars](https://img.shields.io/github/stars/memovai/memov?style=social)
 - [MemTensor/MemOS](https://github.com/MemTensor/MemOS) - Memory operating system with OpenClaw ecosystem adoption. ![GitHub stars](https://img.shields.io/github/stars/MemTensor/MemOS?style=social)


### PR DESCRIPTION
## Summary

- Adds [AgentBase](https://agentbase.tools) to the **Memory and Context Systems** section
- AgentBase is a shared knowledge base where agents store, search, and discover knowledge about any topic via MCP
- GitHub: https://github.com/vhspace/agentbase
- MCP endpoint: https://mcp.agentbase.tools/mcp

## Relevance

AgentBase provides persistent memory and knowledge sharing for AI agents through the MCP protocol, fitting naturally into the Memory and Context Systems category. It enables agents to collaboratively build and query a shared knowledge base.

## Checklist

- [x] Entry follows A-Z ordering within section
- [x] Single bullet line format
- [x] GitHub stars badge included
- [x] Short description included
