### PR TITLE
Add strakelabs/strake-openclaw to Plugins and Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ OpenClaw is an open-source, self-hosted AI agent framework that connects LLMs to
 - [MemTensor/MemOS-Cloud-OpenClaw-Plugin](https://github.com/MemTensor/MemOS-Cloud-OpenClaw-Plugin) - Cloud memory for persistent recall. ![GitHub stars](https://img.shields.io/github/stars/MemTensor/MemOS-Cloud-OpenClaw-Plugin?style=social)
 - [rickybloomfield/OuraClaw](https://github.com/rickybloomfield/OuraClaw) - Oura integration plugin for readiness, sleep, and activity summaries. ![GitHub stars](https://img.shields.io/github/stars/rickybloomfield/OuraClaw?style=social)
 - [soimy/openclaw-channel-dingtalk](https://github.com/soimy/openclaw-channel-dingtalk) - DingTalk enterprise channel plugin with stream support. ![GitHub stars](https://img.shields.io/github/stars/soimy/openclaw-channel-dingtalk?style=social)
+- [strakelabs/strake-openclaw](https://github.com/strakelabs/strake-openclaw) - Provider plugin that routes inference through a Strake encrypted proxy — real API keys stay vault-encrypted,
+  OpenClaw gets a disposable bearer token. Available on [npm](https://www.npmjs.com/package/@strakelabs/openclaw-strake). ![GitHub
+  stars](https://img.shields.io/github/stars/strakelabs/strake-openclaw?style=social)
 - [techartdev/OpenClawHomeAssistant](https://github.com/techartdev/OpenClawHomeAssistant) - Home Assistant add-on with entity-level integration. ![GitHub stars](https://img.shields.io/github/stars/techartdev/OpenClawHomeAssistant?style=social)
 
 ## MCP and Tool Servers


### PR DESCRIPTION
## What this adds

  [strakelabs/strake-openclaw](https://github.com/strakelabs/strake-openclaw) — an OpenClaw provider plugin that routes inference through a Strake encrypted proxy endpoint. Real API keys
  (OpenAI, Anthropic, etc.) stay encrypted in the Strake vault; OpenClaw receives a short-lived, independently revocable bearer token instead.

  - npm: [`@strakelabs/openclaw-strake`](https://www.npmjs.com/package/@strakelabs/openclaw-strake)
  - License: MIT

  ## Relevance note

  Fits **Plugins and Integrations** — it registers Strake as a model provider inside OpenClaw, adding a security/proxy layer without requiring any changes to how OpenClaw consumes the provider.