### PR TITLE
Add ClawClip: Session replay and cost analysis tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Most entries below are community-maintained and are not vetted by OpenClaw. Only
 ## Developer Tooling and Observability
 
 - [bokonon23/clawdbot-cost-monitor](https://github.com/bokonon23/clawdbot-cost-monitor) - Cost and spending monitor for OpenClaw/Clawdbot usage. ![GitHub stars](https://img.shields.io/github/stars/bokonon23/clawdbot-cost-monitor?style=social)
+- [Ylsssq926/clawclip](https://github.com/Ylsssq926/clawclip) - Session replay and version comparison tool for OpenClaw cost analysis. Step-by-step debugging, decision diff, and cross-framework comparison. ![GitHub stars](https://img.shields.io/github/stars/Ylsssq926/clawclip?style=social)
 - [ClawFOMO](https://clawfomo.com) - Real-time trend and sentiment monitor for ecosystem activity.
 - [clawdeckio/clawdeck](https://github.com/clawdeckio/clawdeck) - Mission control dashboard for managing OpenClaw agents. ![GitHub stars](https://img.shields.io/github/stars/clawdeckio/clawdeck?style=social)
 - [crshdn/mission-control](https://github.com/crshdn/mission-control) - Multi-agent orchestration dashboard for OpenClaw gateway workflows. ![GitHub stars](https://img.shields.io/github/stars/crshdn/mission-control?style=social)


### PR DESCRIPTION
## Summary

Add **ClawClip** to the Developer Tooling and Observability section.

## Why ClawClip is still useful alongside OpenClaw's Usage Dashboard

OpenClaw's built-in Usage Dashboard is great for totals and trend tracking.

ClawClip is the drill-down layer for the next set of questions:

- **Why** did one session cost much more than a similar run?
- **Which exact step** or retry chain caused the spike?
- **Did the optimization actually help**, or did it just move cost somewhere else?
- **How does this compare across frameworks** like Hermes Agent, LangGraph, or AutoGen?

## What ClawClip adds

- **Step-by-step session replay** — see every tool call, retry chain, and reasoning block to find exactly where costs spike
- **Version comparison** — compare before/after with decision diff to measure optimization impact
- **Cross-framework support** — works with OpenClaw, Hermes Agent, LangGraph, and AutoGen
- **Solution recommendations** — suggests free-tier alternatives and generates config when it finds waste

**Links:**
- GitHub: https://github.com/Ylsssq926/clawclip
- Demo: https://clawclip.luelan.online

**Placement:** Added after `clawdbot-cost-monitor` in alphabetical order within the Developer Tooling section.

## Checklist

- [x] Entry follows the format: `[repo/name](url) - Description. ![GitHub stars](...)`
- [x] Description is clear and concise
- [x] Placed in correct alphabetical order
- [x] Relevant to OpenClaw ecosystem
- [x] No duplicate entry exists