### PR TITLE
Add Formative Memory to Memory and Context Systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Most entries below are community-maintained and are not vetted by OpenClaw. Only
 - [supermemoryai/openclaw-supermemory](https://github.com/supermemoryai/openclaw-supermemory) - Supermemory-backed long-term memory plugin. 💵 ![GitHub stars](https://img.shields.io/github/stars/supermemoryai/openclaw-supermemory?style=social)
 - [thedotmack/claude-mem](https://github.com/thedotmack/claude-mem/) - Minimal memory layer for Claude/OpenClaw context persistence. ![GitHub stars](https://img.shields.io/github/stars/thedotmack/claude-mem?style=social)
 - [tobi/qmd](https://github.com/tobi/qmd) - Markdown-native memory and knowledge workflows for persistent agent context. ![GitHub stars](https://img.shields.io/github/stars/tobi/qmd?style=social)
+- [jarimustonen/formative-memory](https://github.com/jarimustonen/formative-memory) - Biologically-inspired OpenClaw memory plugin with hybrid (BM25 + embedding) recall, weighted associations, provenance-based reinforcement, and a nightly consolidation ("sleep") loop that decays, prunes, and LLM-merges memories. Single-file SQLite + sqlite-vec. ![GitHub stars](https://img.shields.io/github/stars/jarimustonen/formative-memory?style=social)
 
 ## Developer Tooling and Observability
 


### PR DESCRIPTION
Adding **Formative Memory** to the Memory and Context Systems section.

- **Repo:** https://github.com/jarimustonen/formative-memory
- **License:** MIT
- **Install:** `openclaw plugins install formative-memory`

## What it is

A biologically-inspired memory plugin for OpenClaw. Pre-response auto-recall (hybrid BM25 + embedding, strength-weighted, one-hop association expansion), post-response provenance-based reinforcement that only strengthens memories that actually influenced the reply, and a nightly consolidation ("sleep") loop that decays, prunes, and LLM-merges memories. All mutation is deferred to consolidation so live chat stays read-only.

Single-file SQLite + FTS5 + sqlite-vec — no external services. Content-addressed (SHA-256) memory objects make duplicates structurally impossible. Memories can carry temporal states (future/present/past) that shift automatically.

Sits in the same neighborhood as the existing entries (mem0, memU, MemOS, MoltBrain, supermemory, qmd) but differs mainly in the provenance-based reinforcement loop and the deferred-mutation architecture.

Happy to adjust wording.