### PR TITLE
docs(readme): add 1clawAI/1claw-openclaw-plugin to Plugins and Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Most entries below are community-maintained and are not vetted by OpenClaw. Only
 
 Most entries below are community-maintained and are not vetted by OpenClaw. Only `🎖️` entries are official.
 
+- [1clawAI/1claw-openclaw-plugin](https://github.com/1clawAI/1claw-openclaw-plugin) - 1Claw OpenClaw plugin: HSM-backed secrets, transaction signing, and Shroud TEE for OpenClaw agents. ![GitHub stars](https://img.shields.io/github/stars/1clawAI/1claw-openclaw-plugin?style=social)
 - [11haonb/wecom-openclaw-plugin](https://github.com/11haonb/wecom-openclaw-plugin) - WeCom (WeChat Work) enterprise messaging plugin. ![GitHub stars](https://img.shields.io/github/stars/11haonb/wecom-openclaw-plugin?style=social)
 - [AlexAnys/feishu-openclaw](https://github.com/AlexAnys/feishu-openclaw) - Feishu/Lark integration plugin with streamlined self-hosted setup. ![GitHub stars](https://img.shields.io/github/stars/AlexAnys/feishu-openclaw?style=social)
 - [ClariSortAi/openclaw-manager-plugin](https://github.com/ClariSortAi/openclaw-manager-plugin) - Lifecycle manager for install and configuration workflows. ![GitHub stars](https://img.shields.io/github/stars/ClariSortAi/openclaw-manager-plugin?style=social)


### PR DESCRIPTION
Adds one entry to **Plugins and Integrations** in strict A-Z order (`1clawAI` sorts before the existing first entry `11haonb`), single line, with the required stars badge.

```
- [1clawAI/1claw-openclaw-plugin](https://github.com/1clawAI/1claw-openclaw-plugin) - 1Claw OpenClaw plugin: HSM-backed secrets, transaction signing, and Shroud TEE for OpenClaw agents. ![GitHub stars](https://img.shields.io/github/stars/1clawAI/1claw-openclaw-plugin?style=social)
```

Why it fits: a plugin giving OpenClaw agents hardware-backed key custody, transaction signing, and confidential (TEE) execution — adjacent to but distinct from plain secret-injection entries like onecli.

Affiliation: I represent the project (disclosed per the self-promotion policy).

Resource request issue: #102