### PR TITLE
Add OneClickClaw to Managed Hosting and Setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ These providers handle the setup for you: no Docker, no terminal, no DevOps requ
 - [Kilo Claw](https://kilo.ai/kiloclaw) - Managed OpenClaw platform with SSO and audit features. 💵
 - [MyClaw.ai](https://myclaw.ai/pricing) - Managed OpenClaw instance with instant setup and backups. 💵
 - [Myclawhost](https://www.myclawhost.com/) - Managed OpenClaw hosting with tiered plans. 💵
+- [OneClickClaw](https://oneclickclaw.io) - Managed OpenClaw hosting on a dedicated single-tenant EU VPS, GDPR data residency, BYOK with no token markup, managed updates and backups, hardened by default. 💵
 - [OpenClaw Cloud](https://openclawcloud.work/) - Managed OpenClaw cloud offering (beta). 💵
 - [OpenClaw Hosting](https://openclawhosting.io/pricing) - Managed OpenClaw hosting with solo/team tiers. 💵
 - [OpenClaw Voice](https://openclawvoice.com/) - Managed OpenClaw voice interface in the browser. 💵


### PR DESCRIPTION
Adds OneClickClaw to the Managed Hosting and Setup section. It is a managed OpenClaw hosting service: dedicated single-tenant EU VPS, GDPR data residency, BYOK with no token markup, managed updates and backups, hardened by default. Placed alphabetically between Myclawhost and OpenClaw Cloud, marked as a paid service for consistency with the other entries in that section. One addition, no other changes.