### PR TITLE
Add OneClickClaw.io to Managed Hosting and Setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ These providers handle the setup for you: no Docker, no terminal, no DevOps requ
 - [Kilo Claw](https://kilo.ai/kiloclaw) - Managed OpenClaw platform with SSO and audit features. 💵
 - [MyClaw.ai](https://myclaw.ai/pricing) - Managed OpenClaw instance with instant setup and backups. 💵
 - [Myclawhost](https://www.myclawhost.com/) - Managed OpenClaw hosting with tiered plans. 💵
+- [OneClickClaw.io](https://oneclickclaw.io/openclaw) - Managed OpenClaw hosting on a dedicated EU server per customer. 💵
 - [OpenClaw Cloud](https://openclawcloud.work/) - Managed OpenClaw cloud offering (beta). 💵
 - [OpenClaw Hosting](https://openclawhosting.io/pricing) - Managed OpenClaw hosting with solo/team tiers. 💵
 - [OpenClaw Voice](https://openclawvoice.com/) - Managed OpenClaw voice interface in the browser. 💵


### PR DESCRIPTION
OneClickClaw.io is a managed OpenClaw host based in the EU (Denmark), running since May 2026.

Each customer gets a dedicated VPS rather than a container on a shared machine, which follows OpenClaw's own recommendation of one server per customer.

Plans start at EUR 14.99/month (2 vCPU AMD EPYC, 4 GB RAM, 15 GB NVMe, 2 TB bandwidth), BYOK for the AI provider, with a 7-day free trial that needs no credit card. Setup runs through a web wizard, so no Docker and no terminal, which matches the section's own description.

Placed alphabetically between Myclawhost and OpenClaw Cloud, following the existing one-line format and the marker. One line added, nothing else touched.
